### PR TITLE
Add ability to override web port and host via environment vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN tox -c tox_build.ini -e py36-build && \
 FROM alpine:3.11
 
 ENV WORKER=ENABLE \
-    POLEMARCH_WEB_HOST=0.0.0.0
+    POLEMARCH_WEB_HOST=0.0.0.0 \
     POLEMARCH_WEB_PORT=8080
 
 COPY --from=build /usr/local/project/environment/docker_data/ /etc/polemarch/

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,9 @@ RUN tox -c tox_build.ini -e py36-build && \
 
 FROM alpine:3.11
 
-ENV WORKER=ENABLE
+ENV WORKER=ENABLE \
+    POLEMARCH_WEB_HOST=0.0.0.0
+    POLEMARCH_WEB_PORT=8080
 
 COPY --from=build /usr/local/project/environment/docker_data/ /etc/polemarch/
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -119,7 +119,7 @@ Install from PyPI
 
 
    #. Create directory for `log` and `pid` files:
-      
+
       .. sourcecode:: bash
 
             mkdir /opt/polemarch/logs /opt/polemarch/pid
@@ -205,7 +205,7 @@ For run Polemarch docker image use command:
 
 Using this command download official docker image and run it with default settings. Dont use default SQLite installation with filecache in production.
 
-Polemarch will be run with web interface on port `8080`
+Polemarch will be run with web interface on port `8080` unless specified otherwise by environment variable `POLEMARCH_WEB_PORT`
 
 
 Settings
@@ -213,6 +213,10 @@ Settings
 
 Main section
 ~~~~~~~~~~~~
+
+* **POLEMARCH_WEB_HOST** - host on which web server is listening to. Default value: `0.0.0.0`.
+
+* **POLEMARCH_WEB_PORT** - port on which web server is listening to. Default value: `8080`.
 
 * **POLEMARCH_DEBUG** - status of debug mode. Default value: `false`.
 

--- a/environment/docker_data/settings.ini
+++ b/environment/docker_data/settings.ini
@@ -4,7 +4,7 @@ hooks_dir = /hooks
 
 [uwsgi]
 pidfile = /run/web.pid
-addrport = 0.0.0.0:8080
+addrport = $(POLEMARCH_WEB_HOST):$(POLEMARCH_WEB_PORT)
 vacuum = True
 max-requests = 1000
 max-worker-lifetime = 3600


### PR DESCRIPTION
# Feature - Add ability to override web port and host via environment vars

Two docker env variables added:
- `POLEMARCH_WEB_HOST` - host on which web server is listening to. Default value: `0.0.0.0`.
- `POLEMARCH_WEB_PORT` - port on which web server is listening to. Default value: `8080`.

### BREAKING CHANGES:
*  WNo breaking changes

### Changelog:

* Two docker env variables added `POLEMARCH_WEB_HOST` and `POLEMARCH_WEB_PORT`
